### PR TITLE
Turn sponsor plans into a more visible list, allows direct donations via Stripe forms

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -743,6 +743,10 @@ ul {
   color: white;
 }
 
+.container ul.donation-plans li {
+  padding-top: 20px;
+}
+
 .container ul.donation-plans p {
   text-align: left;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -716,6 +716,48 @@ ul {
     *zoom: 1;
 }
 
+.donation-plans {
+  float: left;
+}
+
+.container ul.donation-plans {
+  width: 1024px;
+  margin-bottom: 40px;
+}
+
+.container ul.donation-plans li {
+  display: inline-block;
+  width: 200px;
+  height: 300px;
+  vertical-align: top;
+  list-style: none;
+  border: 1px solid rgb(34, 34, 34);
+  border-radius: 4px;
+  padding: 5px 10px;
+  margin-right: 20px;
+  text-align: center;
+}
+
+.container ul.donation-plans li:before {
+  content: "";
+  color: white;
+}
+
+.container ul.donation-plans p {
+  text-align: left;
+}
+
+#sponsoring {
+  position: relative;
+}
+
+.donate-button {
+  position: absolute;
+  bottom: 30px;
+  text-align: center;
+  width: 200px;
+}
+
 /* ==========================================================================
    Print styles
    ========================================================================== */

--- a/css/main.css
+++ b/css/main.css
@@ -222,7 +222,8 @@ http://inspectelement.com/tutorials/create-a-slick-css3-button-with-box-shadow-a
 
 .button:active {
   text-decoration: none;
-  position: relative; top: 5px;
+  position: relative;
+  top: 5px;
   -webkit-box-shadow: inset 0px -3px 1px rgba(255, 255, 255, 1), inset 0 0px 3px rgba(0, 0, 0, 0.9);
   -moz-box-shadow: inset 0px -3px 1px rgba(255, 255, 255, 1), inset 0 0px 3px rgba(0, 0, 0, 0.9);
   box-shadow: inset 0px -3px 1px rgba(255, 255, 255, 1), inset 0 0px 3px rgba(0, 0, 0, 0.9);
@@ -721,20 +722,21 @@ ul {
 }
 
 .container ul.donation-plans {
-  width: 1024px;
+  width: 1124px;
   margin-bottom: 40px;
+  padding-left: 0px;
 }
 
 .container ul.donation-plans li {
   display: inline-block;
-  width: 200px;
+  width: 210px;
   height: 300px;
   vertical-align: top;
   list-style: none;
   border: 1px solid rgb(34, 34, 34);
   border-radius: 4px;
-  padding: 5px 10px;
-  margin-right: 20px;
+  padding: 5px 15px;
+  margin-right: 15px;
   text-align: center;
 }
 
@@ -755,11 +757,29 @@ ul {
   position: relative;
 }
 
-.donate-button {
+ul.donation-plans .donate-button {
   position: absolute;
-  bottom: 30px;
+  bottom: 0px;
   text-align: center;
-  width: 200px;
+  width: 180px;
+  margin-bottom: 15px;
+}
+
+.donate-button.button {
+  font-size: 1em;
+  padding: 15px;
+}
+
+ul.donation-plans a.button:active {
+  position: inherit;
+}
+
+.custom-donation input[type=number] {
+  height: 50px;
+  padding: 0px 10px;
+  font-size: 24px;
+  width: 120px;
+  margin-right: 20px;
 }
 
 /* ==========================================================================

--- a/js/main.js
+++ b/js/main.js
@@ -38,6 +38,7 @@ $(document).ready(function() {
 	$(function() {
 
 		var header = $('.intro h2');
+    if (header.length == 0) return;
 		var height = header.height();
 		var pos = Math.floor(header.position().top);
 		var scroll = height + pos;

--- a/sponsors.html
+++ b/sponsors.html
@@ -112,6 +112,11 @@ current: sponsors
   $('#toggle-vat').click(function() {
     document.include_vat = !document.include_vat;
 
+    if (document.include_vat) {
+      $(this).text('Remove VAT');
+    } else {
+      $(this).text('Add VAT')
+    }
     return false;
   });
 </script>

--- a/sponsors.html
+++ b/sponsors.html
@@ -93,11 +93,13 @@ current: sponsors
     if (document.include_vat) {
       amount = amount * 1.19;
     }
+    var donation_package = self.attr('data-name');
 
     var token = function(res){
       var $input = $('<input type=hidden name=stripeToken />').val(res.id);
       var $amount = $('<input type=hidden name=amount />').val(amount);
-      $('form#stripe-form').append($input).append($amount).submit();
+      var $donation_package = $('<input type=hidden name=package />').val(donation_package);
+      $('form#stripe-form').append($input).append($amount).append($donation_package)submit();
     };
 
     StripeCheckout.open({
@@ -106,7 +108,7 @@ current: sponsors
       amount:      amount,
       currency:    'usd',
       name: 'Rails Girls Summer of Code',
-      description: 'Rails Girls Summer of Code: ' + self.attr('data-name') + ' Sponsorship',
+      description: 'Rails Girls Summer of Code: ' + donation_package + ' Sponsorship',
       panelLabel:  'Pay Now',
       token:       token
     });

--- a/sponsors.html
+++ b/sponsors.html
@@ -79,11 +79,6 @@ current: sponsors
 <script>
   $('.donate-button').click(function(){
     var self = $(this);
-    var token = function(res){
-      var $input = $('<input type=hidden name=stripeToken />').val(res.id);
-      $('form#stripe-form').append($input).submit();
-    };
-
     var amount = 0;
     if (self.attr('data-custom')) {
       amount = $('#custom-donation-amount').val();
@@ -98,6 +93,12 @@ current: sponsors
     if (document.include_vat) {
       amount = amount * 1.19;
     }
+
+    var token = function(res){
+      var $input = $('<input type=hidden name=stripeToken />').val(res.id);
+      var $amount = $('<input type=hidden name=amount />').val(amount);
+      $('form#stripe-form').append($input).append($amount).submit();
+    };
 
     StripeCheckout.open({
       key:         '',

--- a/sponsors.html
+++ b/sponsors.html
@@ -48,13 +48,16 @@ current: sponsors
               </li>
             </ul>
 
+            <form id="stripe-form" method="post" action="https://misty-cloud-1233.herokuapp.com">
+            </form>
+
             <p>
               German business or a European business without VAT ID? <a href="#" id="toggle-vat">Add VAT</a>.
             </p>
 
             <div class="custom-donation">
               <strong>Donate a custom amount!</strong>
-              <form>
+              <form onsubmit="return false">
                 <input type="number" id="custom-donation-amount" placeholder="50.00" step="10.00"/>
                 <a href="#" class="donate-button button" data-custom="true" data-name="Custom">Donate Now</a>
               </form>
@@ -78,7 +81,7 @@ current: sponsors
     var self = $(this);
     var token = function(res){
       var $input = $('<input type=hidden name=stripeToken />').val(res.id);
-      $('form').append($input).submit();
+      $('form#stripe-form').append($input).submit();
     };
 
     var amount = 0;
@@ -101,6 +104,7 @@ current: sponsors
       address:     true,
       amount:      amount,
       currency:    'usd',
+      name: 'Rails Girls Summer of Code',
       description: 'Rails Girls Summer of Code: ' + self.attr('data-name') + ' Sponsorship',
       panelLabel:  'Pay Now',
       token:       token

--- a/sponsors.html
+++ b/sponsors.html
@@ -20,21 +20,21 @@ current: sponsors
                   Your logo on our website, lots of tweet love from the community.
                 </p>
 
-                <a href="#" class="donate-button" data-amount="500000" data-name="Bronze">Become a Sponsor!</a>
+                <a href="#" class="donate-button button" data-amount="500000" data-name="Bronze">Become a Sponsor!</a>
               </li>
               <li><strong>Silver - 10,000 USD</strong>
                 <p>
                   Same as bronze, but with a bigger logo on the website and a quote or testimonial from your company in the press kit.
                 </p>
 
-                <a href="#" class="donate-button" data-amount="1000000" data-name="Silver">Become a Sponsor!</a>
+                <a href="#" class="donate-button button" data-amount="1000000" data-name="Silver">Become a Sponsor!</a>
               </li>
               <li><strong>Gold - 15,000 USD</strong>
                 <p>
                   Same as silver, plus your logo in presentations about Rails Girls Summer of Code.
                 </p>
 
-                <a href="#" class="donate-button" data-amount="1500000" data-name="Gold">Become a Sponsor!</a>
+                <a href="#" class="donate-button button" data-amount="1500000" data-name="Gold">Become a Sponsor!</a>
               </li>
               <li><strong>Platinum - 20,000 USD</strong>
                 <p>
@@ -43,12 +43,19 @@ current: sponsors
                 </p>
 
                 <div class="donate-wrapper">
-                  <a href="#" class="donate-button" data-amount="2000000" data-name="Platinum">Become a Sponsor!</a>
+                  <a href="#" class="donate-button button" data-amount="2000000" data-name="Platinum">Become a Sponsor!</a>
                 </div>
               </li>
-                
             </ul>
-                <li><strong>Diamond</strong> - Match the combined contributions of all other sponsors = personalized and special perks, please get in touch with us.</li>
+
+            <div class="custom-donation">
+              <strong>Donate a custom amount!</strong>
+              <form>
+                <input type="number" id="custom-donation-amount" placeholder="50.00" step="10.00"/>
+                <a href="#" class="donate-button button" data-custom="true" data-name="Custom">Donate Now</a>
+              </form>
+            </p>
+
             <p>Logos on the website will be sorted by amount and date. Please read the information on VAT and tax deductibility in the FAQ if you are contributing from within the EU and especially from Germany.</p>
             <p>It is also possible to sponsor a lower amount, we will be happy about it as well. Should you wish, we could put your name in the thank you list.</p>
             <p>Doesn't this sound awesome? Please, drop us a line at <a href="mailto: summer-of-code@railsgirls.com" title="mail to the sponsor-team">summer-of-code@railsgirls.com</a> and mention the magic code "Sponsor" in the subject line. We will get back to you shortly with more details.</p>
@@ -63,26 +70,35 @@ current: sponsors
 </section> <!-- / .main -->
 
 <script>
-  $()
-    $('.donate-button').click(function(){
-      console.log('yo')
-      var self = $(this);
-      var token = function(res){
-        var $input = $('<input type=hidden name=stripeToken />').val(res.id);
-        $('form').append($input).submit();
-      };
+  $('.donate-button').click(function(){
+    var self = $(this);
+    var token = function(res){
+      var $input = $('<input type=hidden name=stripeToken />').val(res.id);
+      $('form').append($input).submit();
+    };
 
-      StripeCheckout.open({
-        key:         '',
-        address:     true,
-        amount:      self.attr('data-amount'),
-        currency:    'usd',
-        description: 'Rails Girls Summer of Code: ' + self.attr('data-name') + ' Sponsorship',
-        panelLabel:  'Pay Now',
-        token:       token
-      });
-
-      return false;
+    var amount = 0;
+    if (self.attr('data-custom')) {
+      amount = $('#custom-donation-amount').val();
+      if (amount === "") {
+        amount = 50;
+      }
+      amount = amount * 100;
+    } else {
+      amount = self.attr('data-amount');
+    }
+    console.log(amount)
+    StripeCheckout.open({
+      key:         '',
+      address:     true,
+      amount:      amount,
+      currency:    'usd',
+      description: 'Rails Girls Summer of Code: ' + self.attr('data-name') + ' Sponsorship',
+      panelLabel:  'Pay Now',
+      token:       token
     });
-  </script>
+
+    return false;
+  });
+</script>
 

--- a/sponsors.html
+++ b/sponsors.html
@@ -48,6 +48,10 @@ current: sponsors
               </li>
             </ul>
 
+            <p>
+              German business or a European business without VAT ID? <a href="#" id="toggle-vat">Add VAT</a>.
+            </p>
+
             <div class="custom-donation">
               <strong>Donate a custom amount!</strong>
               <form>
@@ -87,7 +91,11 @@ current: sponsors
     } else {
       amount = self.attr('data-amount');
     }
-    console.log(amount)
+
+    if (document.include_vat) {
+      amount = amount * 1.19;
+    }
+
     StripeCheckout.open({
       key:         '',
       address:     true,
@@ -97,6 +105,12 @@ current: sponsors
       panelLabel:  'Pay Now',
       token:       token
     });
+
+    return false;
+  });
+
+  $('#toggle-vat').click(function() {
+    document.include_vat = !document.include_vat;
 
     return false;
   });

--- a/sponsors.html
+++ b/sponsors.html
@@ -4,6 +4,9 @@ title: Sponsors
 class: page page-sponsors
 current: sponsors
 ---
+<script src="https://checkout.stripe.com/v2/checkout.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.js"></script>
+
 <section class="main container">
     <div class="wrapper clearfix">
         <article class="content">
@@ -11,32 +14,41 @@ current: sponsors
             <p>Rails Girls Summer of Code will pay the selected students 1500 USD per month for a three months period, so they can dedicate themselves to their Open Source projects full-time. As a sponsor, you will be crucial to make that happen.</p>
             <p>Rails Girls Summer of Code is all about the community. You will support it as a global project, so your sponsorship will enter a budget pool from which the selected students will be paid.</p>
             <p>If you are willing to support us, here is what we offer:</p>
-            <ul>
-                <li><strong>Bronze - 5,000 USD</strong> = logo on the website, lots of tweet love from the community.</li>
-                <li><strong>Silver - 10,000 USD</strong> = same as bronze, but with a bigger logo on the website and a quote or testimonial from your company in the press kit.</li>
-                <li><strong>Gold - 15,000 USD</strong> = same as silver, plus your logo in presentations about Rails Girls Summer of Code.</li>
-                <li><strong>Platinum - 20,000 USD</strong> = same as gold + Konstantin Haase wears a T-shirt from your company at a conference and mentions why.</li>
-                <li><strong>Diamond</strong> - Match the combined contributions of all other sponsors = personalized and special perks, please get in touch with us.</li>
+            <ul class="donation-plans" id="sponsoring">
+              <li><strong>Bronze - 5,000 USD</strong>
+                <p>
+                  Your logo on our website, lots of tweet love from the community.
+                </p>
+
+                <a href="#" class="donate-button" data-amount="500000" data-name="Bronze">Become a Sponsor!</a>
+              </li>
+              <li><strong>Silver - 10,000 USD</strong>
+                <p>
+                  Same as bronze, but with a bigger logo on the website and a quote or testimonial from your company in the press kit.
+                </p>
+
+                <a href="#" class="donate-button" data-amount="1000000" data-name="Silver">Become a Sponsor!</a>
+              </li>
+              <li><strong>Gold - 15,000 USD</strong>
+                <p>
+                  Same as silver, plus your logo in presentations about Rails Girls Summer of Code.
+                </p>
+
+                <a href="#" class="donate-button" data-amount="1500000" data-name="Gold">Become a Sponsor!</a>
+              </li>
+              <li><strong>Platinum - 20,000 USD</strong>
+                <p>
+                  Same as gold + <a href="http://github.com/rkh">Konstantin Haase</a> (Maintainer of Sinatra and Ruby
+                  Hero) wears a T-shirt from your company at a conference and mentions why.
+                </p>
+
+                <div class="donate-wrapper">
+                  <a href="#" class="donate-button" data-amount="2000000" data-name="Platinum">Become a Sponsor!</a>
+                </div>
+              </li>
                 
             </ul>
-            <p>Donation of smaller amounts if you are in the USA </p>
-            <pre> 
-                  Bank name: Congressional Bank
-                  Address: 2101 K St NW, Washington DC, 20037
-                  Routing number: 055003418
-                  Account number: 9030004734
-                        
-            </pre>
-            <p>Donation of smaller amounts if you are in Europe </p>
-            <pre>
-                Name: Travis CI GmbH
-                BIC : WELADED1PMB
-                IBAN: DE37160500001000937166
-                Bank: Mittelbrandenburgische Sparkasse Potsdam
-                BLZ  :16050000
-                Num : 1000937166  
-                
-            </pre>
+                <li><strong>Diamond</strong> - Match the combined contributions of all other sponsors = personalized and special perks, please get in touch with us.</li>
             <p>Logos on the website will be sorted by amount and date. Please read the information on VAT and tax deductibility in the FAQ if you are contributing from within the EU and especially from Germany.</p>
             <p>It is also possible to sponsor a lower amount, we will be happy about it as well. Should you wish, we could put your name in the thank you list.</p>
             <p>Doesn't this sound awesome? Please, drop us a line at <a href="mailto: summer-of-code@railsgirls.com" title="mail to the sponsor-team">summer-of-code@railsgirls.com</a> and mention the magic code "Sponsor" in the subject line. We will get back to you shortly with more details.</p>
@@ -49,3 +61,28 @@ current: sponsors
         </aside>
     </div>
 </section> <!-- / .main -->
+
+<script>
+  $()
+    $('.donate-button').click(function(){
+      console.log('yo')
+      var self = $(this);
+      var token = function(res){
+        var $input = $('<input type=hidden name=stripeToken />').val(res.id);
+        $('form').append($input).submit();
+      };
+
+      StripeCheckout.open({
+        key:         '',
+        address:     true,
+        amount:      self.attr('data-amount'),
+        currency:    'usd',
+        description: 'Rails Girls Summer of Code: ' + self.attr('data-name') + ' Sponsorship',
+        panelLabel:  'Pay Now',
+        token:       token
+      });
+
+      return false;
+    });
+  </script>
+


### PR DESCRIPTION
This is a work in progress, not ready for merging yet, but a basis for discussion.

This changes makes the plans more visible and a bit more distinctive:

![](http://s3itch.paperplanes.de/Sponsors__Rails_Girls_Summer_of_Code_20130525_090914.jpg)

It also adds the possibility of a direct donation via Stripe:

![](http://s3itch.paperplanes.de/Sponsors__Rails_Girls_Summer_of_Code_20130525_091205.jpg)

Needs an addition to support VAT as well, but that could be a smaller link below the "Become a Sponsor" link.

It's also missing the publishable Stripe token to be fully set up.
