### PR TITLE
Add CNAME file for railsgirlssummerofcode.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+railsgirlssummerofcode.org


### PR DESCRIPTION
The domain is fully registered and set up for GitHub pages.
