### PR TITLE
fix for selecting negative amounts in form

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -68,7 +68,7 @@ $(document).ready(function() {
     } else {
       amount = self.attr('data-amount');
     }
-    amount = amount * 100;
+    amount = Math.abs(amount * 100);
 
     var package = self.attr('data-name');
 


### PR DESCRIPTION
this only fixes the amount for the next step. it still allows negative values for the form field.
