### PR TITLE
Improve copy and the campaign page to have more explicit calls to action

### DIFF
--- a/_includes/sponsor_packages.html
+++ b/_includes/sponsor_packages.html
@@ -35,5 +35,7 @@
   </li>
 </ul>
 
+<p class="stripe-note"><small>Secure Payments by Stripe Checkout</small></p>
+
 <p class="footnote"><sup>1</sup> <a href="http://github.com/rkh">Konstantin Haase</a>: Travis CI core member, Sinatra maintainer and Ruby Hero 2012, speaks at many <a href="http://lanyrd.com/profile/konstantinhaase/">conferences</a></p>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,7 +35,7 @@
                 <a href="/" class=""><h1 class="logo-nav ir">Rails Girls Summer of Code</h1></a>
                 <nav class="nav-primary clearfix">
                     <ul>
-                        <li><a href="/campaign" {% if page.current == 'campaign' %}class="current-page"{% endif %}>Campaign</a></li>
+                        <li><a href="/campaign" {% if page.current == 'campaign' %}class="current-page"{% endif %}>Donate Now!</a></li>
                         <li><a href="/students" {% if page.current == 'students' %}class="current-page"{% endif %}>Students</a></li>
                         <li><a href="/sponsors" {% if page.current == 'sponsors' %}class="current-page"{% endif %}>Sponsors</a></li>
                         <li><a href="/projects" {% if page.current == 'projects' %}class="current-page"{% endif %}>Projects</a></li>

--- a/campaign.html
+++ b/campaign.html
@@ -13,7 +13,7 @@ permalink: campaign/
     <article>
       <div class="scribble8" style="float:right"></div>
 
-      <h2>Help us raise <b>$50,000</b> by June 21 2013!</h2>
+      <h2>Help us raise <b>$50,000</b> by June 7 2013!</h2>
 
       <h3>This will help support <b>10</b> Rails Girls students to work on Open Source projects</h3>
 

--- a/campaign.html
+++ b/campaign.html
@@ -13,21 +13,27 @@ permalink: campaign/
     <article>
       <div class="scribble8" style="float:right"></div>
 
-      <h2>{{page.title}}</h2>
-      <p>Rails Girls Summer of Code will pay the selected students 1500 USD per month for a three months period, so they can dedicate themselves to their Open Source projects full-time. For this we are looking for your support.</p>
-      <p>Rails Girls Summer of Code is all about the community. You will support it as a global project, so your donations and sponsorships will enter a budget pool from which the selected students will be paid.</p>
-      <p>For more information on Summer of Code, please see our <a href="/faq">FAQ</a>.</p>
+      <h2>Help us raise <b>$50,000</b> by June 21 2013!</h2>
 
-      <h3>Please donate!</h3>
+      <h3>This will help support <b>10</b> Rails Girls students to work on Open Source projects</h3>
+
+      <p>For every <b>$5,000</b> raised, we can support <b>one student</b>.</p>
 
       <form onsubmit="return false" class="custom-donation">
         <input type="number" id="custom-donation-amount" placeholder="75.00" step="25.00"/>
         <a href="#" class="donate-button button" data-custom="true" data-name="Custom">Donate Now</a>
+        <p class="stripe-note">
+          <small>Secure Payments by Stripe Checkout</small>
+        </p>
       </form>
 
-      <h3>Become a sponsor!</h3>
+      <p>Rails Girls Summer of Code is all about enabling women work full-time on writing fantastic code for<br/>Open Source projects over the course of three months.</p>
+      <p>We can only make this happen with your amazing support. Your donation enables us to pay every<br/>student $5,000 during the Summer of Code. </p>
+      <p>For more information on Summer of Code, please see our <a href="/faq">FAQ</a>.</p>
+
+      <h3>Become An Awesome Sponsor Now!</h3>
       {% include sponsor_packages.html %}
-      <p>Find out more about our <a href="/sponsors">sponsors packages</a>.
+      <p>Find out more about our <a href="/sponsors">sponsoring packages</a>.
 
       <section id="thanks-folks">
         <h2>Thank you!</h2>

--- a/campaign.html
+++ b/campaign.html
@@ -16,7 +16,7 @@ permalink: campaign/
       <h2>{{page.title}}</h2>
       <p>Rails Girls Summer of Code will pay the selected students 1500 USD per month for a three months period, so they can dedicate themselves to their Open Source projects full-time. For this we are looking for your support.</p>
       <p>Rails Girls Summer of Code is all about the community. You will support it as a global project, so your donations and sponsorships will enter a budget pool from which the selected students will be paid.</p>
-      <p>The summer of code will happen no matter what. Any left over money will be kept for next year. In case the Summer of Code is not going to happen for some reason the left over money will be used for a similar non-profit initiative or project.</p>
+      <p>For more information on Summer of Code, please see our <a href="/faq">FAQ</a>.</p>
 
       <h3>Please donate!</h3>
 

--- a/css/main.css
+++ b/css/main.css
@@ -755,7 +755,6 @@ ul {
 
 .container ul.donation-plans {
   width: 1124px;
-  margin-bottom: 40px;
   padding-left: 0px;
 }
 
@@ -802,7 +801,7 @@ ul.donation-plans .donate-button {
 
 .donate-button.button {
   position: relative;
-  top: -2px;
+  top: -3px;
   font-size: 1em;
   padding: 15px;
 }
@@ -812,7 +811,7 @@ ul.donation-plans a.button:active {
 }
 
 .custom-donation {
-  margin-bottom: 3em;
+  margin-bottom: 1em;
 }
 
 .custom-donation .button {
@@ -831,6 +830,10 @@ ul.donation-plans a.button:active {
   font-size: 90%;
 }
 
+.stripe-note {
+  margin-top: 0px;
+  color: #bbb;
+}
 /* ==========================================================================
    Print styles
    ========================================================================== */

--- a/faq.html
+++ b/faq.html
@@ -53,6 +53,23 @@ permalink: faq/
                   <p>We don't really know about tax laws everywhere in the world but according to our tax advisor: "Contributions and payments to Rails Girls Summer of Code are not deductible as charitable contributions for federal income tax purposes. However, they may be deductible under other provisions of the Internal Revenue Code (for US) or your local tax authority's advice."</p>
                   <p>A word about VAT. Sorry to bother you - we'll keep a long story short. If you're not from Europe (to be precise - from the EU) you can skip this. For all the others: we have to struggle with the odd EU VAT regulations for the above mentioned packages. During you fill out the form and entered an EU country we will show a field to ask for your VAT ID. If you have one please enter it - otherwise your contribution will be reduced by 19% VAT. You come from Germany? We will show you a field to ask if VAT is a recoverable tax for you. If so, we will add the 19% VAT to your contribution and ask you to complete your address data.</p>
                 </div>
+                <h3>What happens if we don't reach our goal?</h3>
+                <div>
+                  Summer of Code will offer a reduced amount of spots to students. We currently account for raising
+                  $5000 per student. So if we raise $30,000 we have enough money to fund 6 students.
+                </div>
+                <h3>What happens to my donations if Summer of Code does not go ahead?</h3>
+                <div>
+                  If for some reason the Summer of Code can't go ahead as planned, donors will be offered a refund of
+                  their donation. Alternatively you can decide to have your donation go to the Rails Girls
+                  organization to share your donation with other, future Rails Girls events across the globe.
+                </div>
+                <h3>What happens with any left-over money from the 2013 Summer of Code?</h3>
+                <div>
+                  Any money left over from the campaign will be saved for next year's Rails Girls Summer of Code.
+                  Should there be no Summer of Code in 2014, the Rails Girls organization will decide how to best
+                  spend any left over donation money.
+                </div>
             </div>
         </article>
         <aside class="sidebar">


### PR DESCRIPTION
These changes improve the campaign page (which is now linked to as "Donate Now!" from the menu) to have a bit more explicit copy writing and a more immediate calls to donate money. It also puts a more explicit deadline onto the page. It currently 

![](http://s3itch.paperplanes.de/Campaign__Rails_Girls_Summer_of_Code_20130529_183816.jpg)
