### PR TITLE
Fix wrong order of donations in firefox 21

### DIFF
--- a/js/donations.js
+++ b/js/donations.js
@@ -38,7 +38,8 @@ $.extend(Donations.prototype, {
       crossDomain: true,
       success: function(collection) {
         _this.addIndexes(collection);
-        collection = collection.sort(_this.sort);
+        collection.sort(_this.sort);
+        console.log(collection);
         return _this.pagination = new Pagination(_this, $('.pagination', _this.tbody.parent()), collection, Donations.COUNT);
       }
     });
@@ -67,6 +68,12 @@ $.extend(Donations.prototype, {
   sort: function(lft, rgt) {
     
     var sortByAmount = function(lft, rgt) {
+      if(lft.amount === undefined) {
+        return 1;
+      } 
+      if(rgt.amount === undefined) {
+        return -1;
+      }
         if(lft.amount > rgt.amount) {
            return -1;
          } else if(rgt.amount > lft.amount) {

--- a/js/donations.js
+++ b/js/donations.js
@@ -39,7 +39,6 @@ $.extend(Donations.prototype, {
       success: function(collection) {
         _this.addIndexes(collection);
         collection.sort(_this.sort);
-        console.log(collection);
         return _this.pagination = new Pagination(_this, $('.pagination', _this.tbody.parent()), collection, Donations.COUNT);
       }
     });


### PR DESCRIPTION
The problem here was that firefox seemed to have a different approach for the sorting algorithm. Since the comparison was through .amount the undefined values (which always return false compared to numbers) sort of screwed everything up there. I just noticed because the wrongly ordered sponsors always came after the donors with hidden amounts..
