### PR TITLE
Updated Campaign Page- including pagination of sponsors at bottom of screen

### DIFF
--- a/_includes/sponsor_packages.html
+++ b/_includes/sponsor_packages.html
@@ -37,7 +37,9 @@
 
 <p class="stripe-note"><small>Secure Payments by <a href="https://stripe.com/blog/stripe-checkout">Stripe Checkout</a></small></p>
 
+<p class="footnote"><sup>1</sup> <a href="http://github.com/rkh">Konstantin Haase</a>: Travis CI core member, Sinatra maintainer and Ruby Hero 2012, speaks at many <a href="http://lanyrd.com/profile/konstantinhaase/">conferences</a></p>
+
 <p>For bigger packages please <a href="mailto:summer-of-code@railsgirls.com">get in touch</a>!
 
-<p class="footnote"><sup>1</sup> <a href="http://github.com/rkh">Konstantin Haase</a>: Travis CI core member, Sinatra maintainer and Ruby Hero 2012, speaks at many <a href="http://lanyrd.com/profile/konstantinhaase/">conferences</a></p>
+
 

--- a/campaign.html
+++ b/campaign.html
@@ -21,7 +21,7 @@ permalink: campaign/
       
       <p>But we received so many <strong>fantastic and moving</strong> student applications that we'd like to <strong>support as many as we can.</strong></p>
       
-      <p>So, <strong>for every $5,000 we raise over this, we can add another student</strong> to devote 3 months full time to take their skills to the next level, and get in touch with this amazing Open Source community.</p>
+      <p>So, <strong>for every additional $5,000 we raise, we can help another student</strong> to devote 3 months of full-time effort to take their skills to the next level, and get in touch with this amazing Open Source community.</p>
 
       <form onsubmit="return false" class="custom-donation">
         <input type="number" id="custom-donation-amount" placeholder="75.00" min="0" step="25.00"/>

--- a/campaign.html
+++ b/campaign.html
@@ -71,6 +71,28 @@ permalink: campaign/
             </tr>
           </thead>
           <tbody></tbody>
+          <tfoot>
+            <tr>
+              <td class='pagination' colspan='6'>
+                <span class='page'>Page: <span class='current-page'>1</span><span>/</span><span class='last-page'></span></span>
+                <span class='sep'>&middot;</span>
+                <span class='first'>First</span>
+                <a class='first' href='#'>First</a>
+                <span class='sep'>&middot;</span>
+                <span class='previous'>Previous</span>
+                <a class='previous' href='#'>Previous</a>
+                <span class='sep'>&middot;</span>
+                <span class='next'>Next</span>
+                <a class='next' href='#'>Next</a>
+                <span class='sep'>&middot;</span>
+                <span class='last'>Last</span>
+                <a class='last' href='#'>Last</a>
+                <span class='sep'>&middot;</span>
+                <a class='all' href='#'>See all</a>
+                <a class='paged' href='#'>See less</a>
+              </td>
+            </tr>
+          </tfoot>
           </table>
           
        


### PR DESCRIPTION
Though I've not used gh-pages before, I am hoping to find ways to contribute to the amazing work your group is doing. I've made two adjustments to text and added a footer to the sponsors table so that pagination appears when someone scrolls to the bottom of the page, per the issue reported at https://github.com/rails-girls-summer-of-code/summer-of-code/issues/55

I'm brand new to using GitHub Pages, so I'm having difficulty generating a full preview on my local machine. Please let me know if any of this needs to be done differently. 

Thanks!
Rylee 
