### PR TITLE
comment out student registration button on contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -19,9 +19,9 @@ permalink: contact/
             <div class="scribble6"></div>
         </aside>
         <div class="fullwidth">
-            <a href="https://docs.google.com/forms/d/158MlfRepVVZh9NjskR7-fuNJz5EsgzRnhrmTD94HXwY/viewform" class="button" target="_blank" title="to the student registration">Student registration</a>
+            <!--<a href="https://docs.google.com/forms/d/158MlfRepVVZh9NjskR7-fuNJz5EsgzRnhrmTD94HXwY/viewform" class="button" target="_blank" title="to the student registration">Student registration</a> -->
             <a href="/sponsors" class="button" title="to the sponsor instructions">Sponsor information</a>
-            <a href="https://docs.google.com/forms/d/1hXZ1-pShKo33OaviSlbwY3mVr0ttQTTbuNCXHSQNh4U/viewform" class="button" target="_blank" title="to the project registration">Project registration</a>
+            <a href="https://docs.google.com/forms/d/1hXZ1-pShKo33OaviSlbwY3mVr0ttQTTbuNCXHSQNh4U/viewform" class="button" target="_blank" title="to the project registration">Project registration</a> 
         </div>
     </div>
 </section> <!-- / .main -->


### PR DESCRIPTION
I commented out the button linking to the google docs application form for students, but let the sponsor button and the project button. I figured that we might still want to collect information about potential open source projects for the future.
