### PR TITLE
add companies blog post

### DIFF
--- a/blog/_posts/2014-03-12-companies.md
+++ b/blog/_posts/2014-03-12-companies.md
@@ -1,0 +1,94 @@
+---
+title: "Sponsors, coaching companies and supporting organizers"
+layout: post
+created_at: Wed Mar 11 2014
+permalink: blog/2014
+current: blog
+author: Sara
+twitter: RailsGirlsSoc
+---
+
+
+Rails Girls Summer of Code 2013 was a resounding success!
+
+We had over 30 students working on Open Source projects over the summer, most
+on a full-time basis, sponsored by the community and our company sponsors. A
+significant amount of those students went on to present at conferences, and
+meetups, as well as moved onto their own coding projects!
+
+Preparations for this year's instalment of SoC have begun, and we’re looking
+for companies to support this incredible program in 2014.
+
+This year we have three options for companies to join and support the program;
+as Sponsors, Coaching companies and/or in financially supporting organizers.
+
+## 1. Sponsors
+
+While our fundraising campaign will officially begin on [date], sponsors who
+sign up early will get a significant amount of exposure, and publicity.
+
+Sponsors are listed on the site not only according to the size of their
+donation, but also their sign up date. Our sponsorship packages will remain the
+same as they were in 2013, giving you the opportunity to choose your desired
+package early! Take a look at last year's packages [here].
+
+Sponsor logos will be listed and linked via the Rails Girls Summer of Code
+homepage and on the dedicated 'Sponsors' page, with a blurb text that you are
+free to choose.
+
+Other perks of sponsorship include: getting your swag in goody bags which are
+sent out to our student teams, your logo on students’ slides at conference
+talks, mentions in our press kit and newsletters, blog posts dedicated to
+sponsors, lots of tweet love from the community ... and Konstantin Haase
+wearing your T-shirt and mentioning you as a sponsor at a conference.
+
+Want to be one of our early-bird sponsors? Get in touch with us: [email?]
+
+## 2. Coaching companies
+
+Some of last year's most successful student teams have been supported greatly
+by local ‘coaching companies’, who have given them a place to work in their
+offices and a pool of coaches to help them. We are looking to formalize this
+support into an option for interested companies this year.
+
+A great examples from 2013 is SoundCloud, who sponsored SoC, and provided
+coaching resource for one student team at their Berlin developer office.
+
+Their developers were put into a coaching pool and alloted a certain amount of
+time to coach the students. Students presented their work during company
+meetings, and met with other staff members during lunch breaks. There were a
+number of other companies who provided similar setups with great success, too.
+
+Some companies have policy in place to allow developers to work on Open Source,
+or other beneficial projects, during business hours. If you do, ask your team
+if they'd be interested in coaching a team of two students onsite.
+
+There's one condition to this option: Students CANNOT be picked upfront.
+
+Student applications will be rated based on the set criteria, and the best
+ranked applications will be selected. However, you can greatly improve your
+team's chances of winning a sponsored seat by helping them prepare an
+outstanding application.
+
+If you have the ability to be a 'Coaching Company' we'd love to hear from you:
+[email?]
+
+## 3. Supporting organizers
+
+A mammoth amount of work  goes into organizing Rails Girls Summer of Code, and
+a vast majority of it is done by volunteers. With the program set to grow in
+2014, we would like to provide at least one paid position for an SoC Orga Team
+Member to dedicate themselves to Summer of Code organizational activities.
+
+A great example of financially supporting organizers is Travis CI, which
+supports Rails Girls Summer of Code by paying Anika Lindtner to work on the
+program, through the Travis Foundation.
+
+The sponsored organizer will have displayed a track record of reliability and
+honesty, and will be vetted to ensure they will make terrific use of a paid
+position.
+
+If you are interested in this new initiative, then please get in touch:
+[email?]
+
+

--- a/blog/_posts/2014-03-12-companies.md
+++ b/blog/_posts/2014-03-12-companies.md
@@ -24,16 +24,19 @@ as Sponsors, Coaching companies and/or in financially supporting organizers.
 
 ## 1. Sponsors
 
-While our fundraising campaign will officially begin on [date], sponsors who
-sign up early will get a significant amount of exposure, and publicity.
+While we are going to open our fundraising campaign as soon as possible,
+sponsors who sign up early will get a significant amount of exposure, and
+publicity, since their logo will already be on the website when the hype goes
+off on Twitter.
 
 Sponsors are listed on the site not only according to the size of their
 donation, but also their sign up date. Our sponsorship packages will remain the
 same as they were in 2013, giving you the opportunity to choose your desired
-package early! Take a look at last year's packages [here].
+package early! Take a look at last year's packages
+[here](http://2013.railsgirlssummerofcode.org/campaign).
 
 Sponsor logos will be listed and linked via the Rails Girls Summer of Code
-homepage and on the dedicated 'Sponsors' page, with a blurb text that you are
+homepage and on the dedicated "Sponsors" page, with a blurb text that you are
 free to choose.
 
 Other perks of sponsorship include: getting your swag in goody bags which are
@@ -71,7 +74,7 @@ ranked applications will be selected. However, you can greatly improve your
 team's chances of winning a sponsored seat by helping them prepare an
 outstanding application.
 
-If you have the ability to be a 'Coaching Company' we'd love to hear from you:
+If you have the ability to be a "Coaching Company" we'd love to hear from you:
 [summer-of-code@gmail.org](mailto:summer-of-code@gmail.org)
 
 ## 3. Supporting organizers

--- a/blog/_posts/2014-03-12-companies.md
+++ b/blog/_posts/2014-03-12-companies.md
@@ -16,7 +16,7 @@ on a full-time basis, sponsored by the community and our company sponsors. A
 significant amount of those students went on to present at conferences, and
 meetups, as well as moved onto their own coding projects!
 
-Preparations for this year's instalment of SoC have begun, and we’re looking
+Preparations for this year's instalment of RGSoC have begun, and we’re looking
 for companies to support this incredible program in 2014.
 
 This year we have three options for companies to join and support the program;
@@ -51,12 +51,15 @@ Want to be one of our early-bird sponsors? Get in touch with us:
 ## 2. Coaching companies
 
 Some of last year's most successful student teams have been supported greatly
-by local ‘coaching companies’, who have given them a place to work in their
-offices and a pool of coaches to help them. We are looking to formalize this
-support into an option for interested companies this year.
+by local [coaching companies](http://railsgirlssummerofcode.org/coaching-companies),
+who have given them a place to work in their offices and a pool of coaches to
+help them. We are looking to formalize this support into an option for
+interested companies this year.
 
-A great examples from 2013 is SoundCloud, who sponsored SoC, and provided
-coaching resource for one student team at their Berlin developer office.
+A great examples from 2013 is
+[SoundCloud](http://railsgirlssummerofcode.org/blog/soundcloud-gold-sponsor),
+who sponsored RGSoC, and provided coaching resource for one student team at
+their Berlin developer office.
 
 Their developers were put into a coaching pool and alloted a certain amount of
 time to coach the students. Students presented their work during company
@@ -69,10 +72,10 @@ if they'd be interested in coaching a team of two students onsite.
 
 There's one condition to this option: Students CANNOT be picked upfront.
 
-Student applications will be rated based on the set criteria, and the best
-ranked applications will be selected. However, you can greatly improve your
-team's chances of winning a sponsored seat by helping them prepare an
-outstanding application.
+[Student applications](http://railsgirlssummerofcode.org/application-guide/)
+will be rated based on the set criteria, and the best ranked applications will
+be selected. However, you can greatly improve your team's chances of winning a
+sponsored seat by helping them prepare an outstanding application.
 
 If you have the ability to be a "Coaching Company" we'd love to hear from you:
 [summer-of-code@gmail.org](mailto:summer-of-code@gmail.org)
@@ -80,13 +83,13 @@ If you have the ability to be a "Coaching Company" we'd love to hear from you:
 ## 3. Supporting organizers
 
 A mammoth amount of work  goes into organizing Rails Girls Summer of Code, and
-a vast majority of it is done by volunteers. With the program set to grow in
-2014, we would like to provide at least one paid position for an SoC Orga Team
-Member to dedicate themselves to Summer of Code organizational activities.
+a vast majority of it is done by volunteers. We would like to provide another
+paid position for an RGSoC Orga Team Member to dedicate themselves to Summer of
+Code organizational activities part- or fulltime.
 
-A great example of financially supporting organizers is Travis CI, which
-supports Rails Girls Summer of Code by paying Anika Lindtner to work on the
-program, through the Travis Foundation.
+A great example of financially supporting organizers is [Travis CI](http://travis-ci.com),
+who support Rails Girls Summer of Code by paying Anika Lindtner to work on the
+program, through the [Travis Foundation](http://foundation.travis-ci.com).
 
 The sponsored organizer will have displayed a track record of reliability and
 honesty, and will be vetted to ensure they will make terrific use of a paid

--- a/blog/_posts/2014-03-12-companies.md
+++ b/blog/_posts/2014-03-12-companies.md
@@ -42,7 +42,8 @@ talks, mentions in our press kit and newsletters, blog posts dedicated to
 sponsors, lots of tweet love from the community ... and Konstantin Haase
 wearing your T-shirt and mentioning you as a sponsor at a conference.
 
-Want to be one of our early-bird sponsors? Get in touch with us: [email?]
+Want to be one of our early-bird sponsors? Get in touch with us:
+[summer-of-code@gmail.org](mailto:summer-of-code@gmail.org)
 
 ## 2. Coaching companies
 
@@ -71,7 +72,7 @@ team's chances of winning a sponsored seat by helping them prepare an
 outstanding application.
 
 If you have the ability to be a 'Coaching Company' we'd love to hear from you:
-[email?]
+[summer-of-code@gmail.org](mailto:summer-of-code@gmail.org)
 
 ## 3. Supporting organizers
 
@@ -89,6 +90,5 @@ honesty, and will be vetted to ensure they will make terrific use of a paid
 position.
 
 If you are interested in this new initiative, then please get in touch:
-[email?]
-
+[summer-of-code@gmail.org](mailto:summer-of-code@gmail.org)
 

--- a/blog/_posts/2014-03-12-companies.md
+++ b/blog/_posts/2014-03-12-companies.md
@@ -1,7 +1,7 @@
 ---
-title: "Sponsors, coaching companies and supporting organizers"
+title: "3 Ways Your Company Can Support Rails Girls Summer of Code 2014"
 layout: post
-created_at: Wed Mar 11 2014
+created_at: Thur Mar 13 2014
 permalink: blog/2014
 current: blog
 author: Sara

--- a/blog/_posts/2014-03-12-companies.md
+++ b/blog/_posts/2014-03-12-companies.md
@@ -57,7 +57,7 @@ help them. We are looking to formalize this support into an option for
 interested companies this year.
 
 A great examples from 2013 is
-[SoundCloud](http://railsgirlssummerofcode.org/blog/soundcloud-gold-sponsor),
+[SoundCloud](http://blog.soundcloud.com/2013/07/19/rails-girls-summer-of-code-welcoming-nicole-and-laura),
 who sponsored RGSoC, and provided coaching resource for one student team at
 their Berlin developer office.
 


### PR DESCRIPTION
Is this a good title? What's a better one?

Other things to be done:
- [x] add the email address, which one do we use? summer-of-code@gmail.org?
- [x] add the date for the campaign start
- [x] link to relevant external pages, e.g. Travis Foundation
- [x] link to the coaching companies page, if available, yet (we should try!)
