### PR TITLE
Fix the inline link in http://railsgirlssummerofcode.org/about/ to the code of conduct

### DIFF
--- a/about.md
+++ b/about.md
@@ -29,7 +29,7 @@ community.
 Make help make Open Source a better place for everyone.
 
 We want to provide a safe space for everyone involved. Please read our
-[Code of Conduct](/code-of-conduct).
+[Code of Conduct](/about/code-of-conduct).
 
 
 ### Get in touch


### PR DESCRIPTION
The inline link from http://railsgirlssummerofcode.org/about to the code of conduct is presently not working, as it points to http://railsgirlssummerofcode.org/code-of-conduct , but the code of conduct is at http://railsgirlssummerofcode.org/about/code-of-conduct .

This pull request fixes that minor goof.
