### PR TITLE
Fix created_at

### DIFF
--- a/blog/_posts/2014-07-24-conferences.md
+++ b/blog/_posts/2014-07-24-conferences.md
@@ -1,7 +1,7 @@
 ---
 title: "Get your ticket to one (or more!) of these great conferences"
 layout: post
-created_at: Thu May 22 2014
+created_at: Thu Jul 24 2014
 permalink: blog/2014-07-24-conferences
 current: blog
 author: Floor


### PR DESCRIPTION
I think this is the reason why in the blog site says "Posted on May 22, 2014"

![fix typo](https://www.evernote.com/shard/s162/sh/adc41f22-899e-41ee-9046-deb0c04b8435/8693719fd362b92d95a28c23cb0ff416/deep/0/Get-your-ticket-to-one-%28or-more!%29-of-these-great-conferences---Rails-Girls-Summer-of-Code.png)
