### PR TITLE
Link RGSoC projects

### DIFF
--- a/blog/_posts/2014-10-06-finale.md
+++ b/blog/_posts/2014-10-06-finale.md
@@ -11,7 +11,7 @@ twitter: RailsGirlsSoc
 
 It's real. We can't believe it, it's been such a wonderful journey. These were the last days of the Summer of Code!
 
-The program came to an official end as of the 30th of September, so we took a few days to think about the things we enjoyed most about this year’s proceedings. We asked the people behind RGSoC to take some selfies to share their favorite moment/lesson/thing of their summer or a message for you. 
+The program came to an official end as of the 30th of September, so we took a few days to think about the things we enjoyed most about this year’s proceedings. We asked the people behind RGSoC to take some selfies to share their favorite moment/lesson/thing of their summer or a message for you.
 
 
 <img src="https://cloud.githubusercontent.com/assets/1307818/4518721/2c3f7ac4-4c9b-11e4-86d0-053e714cbcb7.gif" width="700">
@@ -53,7 +53,12 @@ To everyone who said *"It's going to be me."* - to supporting RGSoC, to supporti
 
 With the help of the wonderful community we raised $95 k, and with that money we were able to provide sponsorship to 10 teams - that's 20 participants. We also had 6 amazing volunteer teams this year, wich brings us to 32 students in total.  [32 stories to tell](http://teams.railsgirlssummerofcode.org/), 32 new beginnings.
 
-The teams worked on projects such as Rubinius, Spree, Bundler, Diaspora*, BrowserSpree CMS, Speakerinnen, Species+, created a tool for documentation testing or started a migraine tracker - to only name a few. Meet the teams here: [http://teams.railsgirlssummerofcode.org/teams](http://teams.railsgirlssummerofcode.org/teams).
+The teams worked on projects such as [Rubinius](http://rubini.us/),
+[Spree](https://github.com/spree/spree), [Bundler](http://bundler.io/),
+[Diaspora*](https://diasporafoundation.org/), BrowserSpree CMS, [Speakerinnen](https://speakerinnen.org/en),
+Species+, created a tool for documentation testing or started a migraine
+tracker - to only name a few. Meet the teams here:
+[http://teams.railsgirlssummerofcode.org/teams](http://teams.railsgirlssummerofcode.org/teams).
 
 
 ### Something to remember the summer


### PR DESCRIPTION
Adds links to the canonical websites of the listed projects. That is: where I could find one within a 30secs search timeframe. If anyone can point me to the missing ones, I'll gladly add those, too.
